### PR TITLE
 Allow `DisableCosmosConnectionModeDirect ` app setting to be set to `true` to bypass Cosmos 'Direct' connection mode

### DIFF
--- a/SFB.Artifacts.Infrastructure/Helpers/AppSettings.cs
+++ b/SFB.Artifacts.Infrastructure/Helpers/AppSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace SFB.Artifacts.Infrastructure.Helpers
+{
+    public static class AppSettings
+    {
+        public const string DisableCosmosConnectionModeDirect = "DisableCosmosConnectionModeDirect";
+    }
+}

--- a/SFB.Artifacts.Infrastructure/Helpers/DataCollectionManager.cs
+++ b/SFB.Artifacts.Infrastructure/Helpers/DataCollectionManager.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Cosmos.Fluent;
 using Newtonsoft.Json.Linq;
+using SFB.Artifacts.Infrastructure.Helpers;
 using SFB.Web.ApplicationCore.DataAccess;
 using SFB.Web.ApplicationCore.Helpers.Constants;
 using SFB.Web.ApplicationCore.Helpers.Enums;
@@ -27,9 +28,9 @@ namespace SFB.Web.Infrastructure.Helpers
             var clientBuilder = new CosmosClientBuilder(ConfigurationManager.AppSettings["endpoint"],
                 ConfigurationManager.AppSettings["authKey"]);
 
-            _client = clientBuilder
-                                .WithConnectionModeDirect()
-                                .Build();
+            _client = ConfigurationManager.AppSettings[AppSettings.DisableCosmosConnectionModeDirect] == bool.TrueString 
+                ? clientBuilder.Build() 
+                : clientBuilder.WithConnectionModeDirect().Build();
 
             _databaseId = ConfigurationManager.AppSettings["database"];
 

--- a/SFB.Artifacts.Infrastructure/Repositories/CosmosDBEfficiencyMetricRepository.cs
+++ b/SFB.Artifacts.Infrastructure/Repositories/CosmosDBEfficiencyMetricRepository.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.Linq;
 using System.Threading.Tasks;
+using SFB.Artifacts.Infrastructure.Helpers;
 
 namespace SFB.Web.Infrastructure.Repositories
 {
@@ -20,7 +21,9 @@ namespace SFB.Web.Infrastructure.Repositories
         {
             var clientBuilder = new CosmosClientBuilder(ConfigurationManager.AppSettings["endpoint"], ConfigurationManager.AppSettings["authKey"]);
 
-            _client = clientBuilder.WithConnectionModeDirect().Build();
+            _client = ConfigurationManager.AppSettings[AppSettings.DisableCosmosConnectionModeDirect] == bool.TrueString
+                ? clientBuilder.Build() 
+                : clientBuilder.WithConnectionModeDirect().Build();
 
             _databaseId = ConfigurationManager.AppSettings["database"];
 

--- a/SFB.Artifacts.Infrastructure/Repositories/CosmosDBSelfAssesmentDashboardRepository.cs
+++ b/SFB.Artifacts.Infrastructure/Repositories/CosmosDBSelfAssesmentDashboardRepository.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.Linq;
 using System.Threading.Tasks;
+using SFB.Artifacts.Infrastructure.Helpers;
 
 namespace SFB.Web.Infrastructure.Repositories
 {
@@ -23,7 +24,9 @@ namespace SFB.Web.Infrastructure.Repositories
         {
             var clientBuilder = new CosmosClientBuilder(ConfigurationManager.AppSettings["endpoint"], ConfigurationManager.AppSettings["authKey"]);
 
-            _client = clientBuilder.WithConnectionModeDirect().Build();
+            _client = ConfigurationManager.AppSettings[AppSettings.DisableCosmosConnectionModeDirect] == bool.TrueString
+                ? clientBuilder.Build() 
+                : clientBuilder.WithConnectionModeDirect().Build();
 
             _databaseId = _databaseId = ConfigurationManager.AppSettings["database"];
 

--- a/SFB.Artifacts.Infrastructure/Repositories/CosmosDbEdubaseRepository.cs
+++ b/SFB.Artifacts.Infrastructure/Repositories/CosmosDbEdubaseRepository.cs
@@ -11,6 +11,7 @@ using System.Configuration;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using SFB.Artifacts.Infrastructure.Helpers;
 
 namespace SFB.Web.Infrastructure.Repositories
 {
@@ -26,7 +27,9 @@ namespace SFB.Web.Infrastructure.Repositories
 
             var clientBuilder = new CosmosClientBuilder(ConfigurationManager.AppSettings["endpoint"], ConfigurationManager.AppSettings["authKey"]);
 
-            _client = clientBuilder.WithConnectionModeDirect().Build();
+            _client = ConfigurationManager.AppSettings[AppSettings.DisableCosmosConnectionModeDirect] == bool.TrueString
+                ? clientBuilder.Build() 
+                : clientBuilder.WithConnectionModeDirect().Build();
 
             _databaseId = ConfigurationManager.AppSettings["database"];
 

--- a/SFB.Artifacts.Infrastructure/Repositories/CosmosDbFinancialDataRepository.cs
+++ b/SFB.Artifacts.Infrastructure/Repositories/CosmosDbFinancialDataRepository.cs
@@ -13,6 +13,7 @@ using SFB.Web.ApplicationCore.Helpers.Constants;
 using SFB.Web.ApplicationCore.Models;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Cosmos.Fluent;
+using SFB.Artifacts.Infrastructure.Helpers;
 using SFB.Web.Infrastructure.Logging;
 
 namespace SFB.Web.Infrastructure.Repositories
@@ -30,7 +31,9 @@ namespace SFB.Web.Infrastructure.Repositories
             var clientBuilder = new CosmosClientBuilder(ConfigurationManager.AppSettings["endpoint"],
                 ConfigurationManager.AppSettings["authKey"]);
 
-            _client = clientBuilder.WithConnectionModeDirect().Build();
+            _client = ConfigurationManager.AppSettings[AppSettings.DisableCosmosConnectionModeDirect] == bool.TrueString
+                ? clientBuilder.Build() 
+                : clientBuilder.WithConnectionModeDirect().Build();
 
             _databaseId = ConfigurationManager.AppSettings["database"];
         }

--- a/SFB.Artifacts.Infrastructure/Repositories/CosmosDbTrustHistoryRepository.cs
+++ b/SFB.Artifacts.Infrastructure/Repositories/CosmosDbTrustHistoryRepository.cs
@@ -7,6 +7,7 @@ using SFB.Web.Infrastructure.Logging;
 using System.Configuration;
 using System.Linq;
 using System.Threading.Tasks;
+using SFB.Artifacts.Infrastructure.Helpers;
 
 
 namespace SFB.Web.Infrastructure.Repositories
@@ -21,7 +22,9 @@ namespace SFB.Web.Infrastructure.Repositories
         {
             var clientBuilder = new CosmosClientBuilder(ConfigurationManager.AppSettings["endpoint"], ConfigurationManager.AppSettings["authKey"]);
 
-            _client = clientBuilder.WithConnectionModeDirect().Build();
+            _client = ConfigurationManager.AppSettings[AppSettings.DisableCosmosConnectionModeDirect] == bool.TrueString
+                ? clientBuilder.Build() 
+                : clientBuilder.WithConnectionModeDirect().Build();
 
             _databaseId = _databaseId = ConfigurationManager.AppSettings["database"];
 


### PR DESCRIPTION
This will allow local dev machines to communicate with Cosmos in non-direct mode